### PR TITLE
Define connection_direction to prevent deprecated notice in php 8.3

### DIFF
--- a/src/TAD/Pipe/AbstractPipe.php
+++ b/src/TAD/Pipe/AbstractPipe.php
@@ -6,6 +6,11 @@ class TAD_Pipe_AbstractPipe implements TAD_Pipe_SettablePropertiesInterface {
 	/**
 	 * @var string
 	 */
+	public $connection_direction;
+
+	/**
+	 * @var string
+	 */
 	protected $field_id;
 
 	/**


### PR DESCRIPTION
Initial notice:
[24-Jul-2024 09:55:53 UTC] [8192] Creation of dynamic property TAD_Pipe_P2PPipe::$connection_direction is deprecated, /home/vagrant/src/popcorn-pass-web/html/content/mu-plugins/cmb2-pipes/src/TAD/Pipe/AbstractPipe.php:40
